### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,14 +40,18 @@ CFILES		:=	$(call GET_FILES,c)
 SFILES		:=	$(call GET_FILES,s)
 OFILES		:=	$(patsubst $(SOURCE)/%,$(BUILD)/%,$(CFILES:.c=.o) $(SFILES:.s=.o))
 
-.PHONY: clean
+.PHONY: install clean
 
-$(foreach f,lib/$(TARGET).a $(OFILES),$(eval $f : | $(dir $f)/D))
+$(foreach f,$(BUILD)/$(TARGET).a $(OFILES),$(eval $f : | $(dir $f)/D))
 
-lib/$(TARGET).a	:	$(OFILES)
+$(BUILD)/$(TARGET).a	:	$(OFILES)
 
 %/D:
 	@[ -d $(dir $@) ] || mkdir -p $(dir $@)
+
+install: $(BUILD)/$(TARGET).a include
+	cp -R include $(DESTDIR)
+	cp $(BUILD)/$(TARGET).a -t $(DESTDIR)/lib
 
 clean:
 	@echo clean ...


### PR DESCRIPTION
This changes are made for including this library in rxTools.
# dbdd4f9654b3ccbac3ef554b696a6f507a4365c2

Calling itself makes impossible to specify files you intended to let it make.
# d209e5d0e2ea8a0c936730a9025783fff3a359e9

The Makefile outputs the library in the current directory. However, I don't want to make files anywhere else the unified `BUILD` directory in `rxTools/rxtools`. This change will remove the code to make `lib` directory and add `install` rule instead of that.
